### PR TITLE
Fix removing KEYCLOAK_ADAPTER_STATE cookie

### DIFF
--- a/adapters/spi/jetty-adapter-spi/pom.xml
+++ b/adapters/spi/jetty-adapter-spi/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-jetty-adapter-spi</artifactId>
+    <groupId>com.avsystem.keycloak</groupId>
     <name>Keycloak Jetty Adapter SPI</name>
     <properties>
         <maven.compiler.target>1.7</maven.compiler.target>

--- a/adapters/spi/jetty-adapter-spi/src/main/java/org/keycloak/adapters/jetty/spi/JettyHttpFacade.java
+++ b/adapters/spi/jetty-adapter-spi/src/main/java/org/keycloak/adapters/jetty/spi/JettyHttpFacade.java
@@ -205,7 +205,7 @@ public class JettyHttpFacade implements HttpFacade {
 
         @Override
         public void resetCookie(String name, String path) {
-            setCookie(name, "", null, path, 0, false, false);
+            setCookie(name, "", path, null, 0, false, false);
         }
 
         @Override


### PR DESCRIPTION
This commit provides a fix for removing KEYCLOAK_ADAPTER_STATE cookie
by using 'path' and 'domain' parameters properly.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
